### PR TITLE
fix: preserve investor contribution view compatibility

### DIFF
--- a/migrations_v4/000200_supply_return_reporting_views.up.sql
+++ b/migrations_v4/000200_supply_return_reporting_views.up.sql
@@ -368,6 +368,23 @@ SELECT
     COALESCE(rri.rent_real_usd, 0) +
     COALESCE(ia.admin_real_usd, 0)
   )::numeric AS total_real_contribution_usd,
+  ct.total_contributions_usd AS project_total_contributions_usd,
+  CASE
+    WHEN ct.total_contributions_usd > 0
+    THEN (
+      (
+        COALESCE(agro.agrochemicals_real_usd, 0) +
+        COALESCE(fert.fertilizers_real_usd, 0) +
+        COALESCE(seed.seeds_real_usd, 0) +
+        COALESCE(glabor.general_labors_real_usd, 0) +
+        COALESCE(sow.sowing_real_usd, 0) +
+        COALESCE(irrig.irrigation_real_usd, 0) +
+        COALESCE(rri.rent_real_usd, 0) +
+        COALESCE(ia.admin_real_usd, 0)
+      ) / ct.total_contributions_usd * 100
+    )::numeric
+    ELSE 0::numeric
+  END AS contributions_progress_pct,
   (
     COALESCE(agro.agrochemicals_real_usd, 0) - (ct.agrochemicals_total_usd * ib.share_pct_agreed / 100)
   )::numeric AS agrochemicals_diff_usd,


### PR DESCRIPTION
Keep the existing investor contribution columns while adding the new reporting fields so the migration can run on deployed databases without breaking dependent views.

Made-with: Cursor