### PR TITLE
fix(migrations): drop work_order_drafts.reviewed_by FK in auth_uuid

### DIFF
--- a/migrations_v4/000209_auth_uuid_migration.up.sql
+++ b/migrations_v4/000209_auth_uuid_migration.up.sql
@@ -46,6 +46,8 @@ ALTER TABLE public.project_investors DROP CONSTRAINT IF EXISTS fk_project_invest
 ALTER TABLE public.project_investors DROP CONSTRAINT IF EXISTS fk_project_investors_updated_by;
 ALTER TABLE public.project_investors DROP CONSTRAINT IF EXISTS fk_project_investors_deleted_by;
 
+ALTER TABLE public.work_order_drafts DROP CONSTRAINT IF EXISTS fk_work_order_drafts_reviewed_by;
+
 -- =============================================================================
 -- 2. Convert actor columns to text
 -- =============================================================================
@@ -136,6 +138,8 @@ ALTER TABLE public.business_parameters ALTER COLUMN deleted_by TYPE text USING d
 ALTER TABLE public.invoices ALTER COLUMN created_by TYPE text USING created_by::text;
 ALTER TABLE public.invoices ALTER COLUMN updated_by TYPE text USING updated_by::text;
 ALTER TABLE public.invoices ALTER COLUMN deleted_by TYPE text USING deleted_by::text;
+
+ALTER TABLE public.work_order_drafts ALTER COLUMN reviewed_by TYPE text USING reviewed_by::text;
 
 ALTER TABLE public.crop_commercializations ALTER COLUMN created_by TYPE text USING created_by::text;
 ALTER TABLE public.crop_commercializations ALTER COLUMN updated_by TYPE text USING updated_by::text;


### PR DESCRIPTION
## Summary

El reset-db-dev-from-staging fallaba en la migración 209 (auth_uuid) con \`cannot drop constraint pk_users on table users because other objects depend on it\`.

Causa: \`work_order_drafts\` (199) crea FK \`fk_work_order_drafts_reviewed_by\` apuntando a \`users(id)\` cuando users.id es bigint. Cuando 209 intenta cambiar users.id a uuid, esa FK lo bloquea.

Fix: en 209 agregar al bloque inicial de DROP FKs el drop de \`fk_work_order_drafts_reviewed_by\`, y al bloque de "convert actor columns to text" agregar la conversión de \`reviewed_by\` a text. Mismo patrón que las demás actor columns.

## Test plan
- [ ] Re-ejecutar workflow reset-db-dev-from-staging
- [ ] Verificar que el deploy a dev pase

🤖 Generated with [Claude Code](https://claude.com/claude-code)