### PR TITLE
Hotfix: última orden creada en dashboard

### DIFF
--- a/internal/dashboard/handler.go
+++ b/internal/dashboard/handler.go
@@ -73,6 +73,10 @@ func (h *Handler) GetDashboard(c *gin.Context) {
 		sharedhandlers.RespondError(c, err)
 		return
 	}
+	if err := sharedhandlers.ValidateRequiredWorkspaceFilter(workspaceFilter); err != nil {
+		sharedhandlers.RespondError(c, err)
+		return
+	}
 
 	filter := domain.DashboardFilter{
 		CustomerID: workspaceFilter.CustomerID,

--- a/internal/report/handler.go
+++ b/internal/report/handler.go
@@ -138,6 +138,9 @@ func (h *ReportHandler) parseReportFilters(c *gin.Context) (domain.ReportFilter,
 	if err != nil {
 		return filters, err
 	}
+	if err := sharedhandlers.ValidateRequiredWorkspaceFilter(workspaceFilter); err != nil {
+		return filters, err
+	}
 	filters.CustomerID = workspaceFilter.CustomerID
 	filters.ProjectID = workspaceFilter.ProjectID
 	filters.CampaignID = workspaceFilter.CampaignID
@@ -151,7 +154,11 @@ func (h *ReportHandler) parseSummaryFilters(c *gin.Context) (domain.SummaryResul
 	if err := c.ShouldBindQuery(&request); err != nil {
 		return domain.SummaryResultsFilter{}, domainerr.Validation("invalid summary filters")
 	}
-	return dto.ToDomainSummaryResultsFilter(request), nil
+	filter := dto.ToDomainSummaryResultsFilter(request)
+	if filter.CustomerID == nil || filter.ProjectID == nil || filter.CampaignID == nil {
+		return domain.SummaryResultsFilter{}, domainerr.Validation("customer_id, project_id and campaign_id are required")
+	}
+	return filter, nil
 }
 
 // buildReportByType construye el reporte según el tipo.

--- a/internal/report/usecases.go
+++ b/internal/report/usecases.go
@@ -78,8 +78,8 @@ func (uc *ReportUseCase) GetInvestorContributionReport(ctx context.Context, filt
 
 // GetSummaryResultsReport obtiene el reporte de resumen de resultados.
 func (uc *ReportUseCase) GetSummaryResultsReport(filters domain.SummaryResultsFilter) (*domain.SummaryResultsResponse, error) {
-	// Validar que al menos un filtro esté presente
-	if err := uc.validator.ValidateAtLeastOneFilter(filters); err != nil {
+	// Validar workspace completo: customer_id + project_id + campaign_id
+	if err := uc.validator.ValidateRequiredWorkspaceFilter(filters); err != nil {
 		return nil, err
 	}
 

--- a/internal/report/usecases/validators.go
+++ b/internal/report/usecases/validators.go
@@ -15,21 +15,11 @@ func NewReportFilterValidator() *ReportFilterValidator {
 	return &ReportFilterValidator{}
 }
 
-// ValidateAtLeastOneFilter valida que al menos un filtro esté presente.
-func (v *ReportFilterValidator) ValidateAtLeastOneFilter(filter domain.SummaryResultsFilter) error {
-	if filter.ProjectID == nil &&
-		filter.CustomerID == nil &&
-		filter.CampaignID == nil &&
-		filter.FieldID == nil {
-		return fmt.Errorf("at least one filter must be specified (project_id, customer_id, campaign_id, or field_id)")
+// ValidateRequiredWorkspaceFilter valida que el workspace esté completo:
+// customer_id, project_id y campaign_id son obligatorios; field_id es opcional.
+func (v *ReportFilterValidator) ValidateRequiredWorkspaceFilter(filter domain.SummaryResultsFilter) error {
+	if filter.ProjectID == nil || filter.CustomerID == nil || filter.CampaignID == nil {
+		return fmt.Errorf("customer_id, project_id and campaign_id are required")
 	}
 	return nil
-}
-
-// HasAnyFilter verifica si hay al menos un filtro presente.
-func (v *ReportFilterValidator) HasAnyFilter(filter domain.SummaryResultsFilter) bool {
-	return filter.ProjectID != nil ||
-		filter.CustomerID != nil ||
-		filter.CampaignID != nil ||
-		filter.FieldID != nil
 }

--- a/internal/shared/handlers/workspace_filters.go
+++ b/internal/shared/handlers/workspace_filters.go
@@ -41,6 +41,15 @@ func ParseWorkspaceFilter(c *gin.Context) (filters.WorkspaceFilter, error) {
 	return out, nil
 }
 
+// ValidateRequiredWorkspaceFilter exige customer_id, project_id y campaign_id;
+// field_id sigue siendo opcional y su ausencia representa "todos los campos".
+func ValidateRequiredWorkspaceFilter(f filters.WorkspaceFilter) error {
+	if f.CustomerID == nil || f.ProjectID == nil || f.CampaignID == nil {
+		return domainerr.Validation("customer_id, project_id and campaign_id are required")
+	}
+	return nil
+}
+
 // ParseProjectIDParam valida el project_id de path contra la query si existe.
 func ParseProjectIDParam(c *gin.Context, paramName string) (int64, error) {
 	projectID, err := ginmw.ParseParamID(c, paramName)

--- a/internal/work-order/repository.go
+++ b/internal/work-order/repository.go
@@ -417,7 +417,7 @@ func (r *Repository) ListWorkOrders(
 	if err := base.
 		Limit(int(inp.PageSize)).
 		Offset(offset).
-		Order("number desc").
+		Order("id desc").
 		Find(&rows).Error; err != nil {
 		return nil, types.PageInfo{}, domainerr.Internal(
 			"failed to list work orders")

--- a/internal/work-order/repository_list_test.go
+++ b/internal/work-order/repository_list_test.go
@@ -1,0 +1,83 @@
+package workorder
+
+import (
+	"context"
+	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	types "github.com/devpablocristo/ponti-backend/internal/shared/types"
+	domain "github.com/devpablocristo/ponti-backend/internal/work-order/usecases/domain"
+)
+
+type listTestGormEngine struct {
+	client *gorm.DB
+}
+
+func (e *listTestGormEngine) Client() *gorm.DB {
+	return e.client
+}
+
+func newListWorkOrdersTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+
+	statements := []string{
+		`CREATE TABLE projects (
+			id INTEGER PRIMARY KEY,
+			deleted_at DATETIME
+		);`,
+		`ATTACH DATABASE ':memory:' AS v4_report;`,
+		`CREATE TABLE v4_report.workorder_list (
+			id INTEGER,
+			number TEXT,
+			project_id INTEGER,
+			field_id INTEGER
+		);`,
+		`INSERT INTO projects (id, deleted_at) VALUES (30, NULL);`,
+		`INSERT INTO v4_report.workorder_list (id, number, project_id, field_id) VALUES
+			(10, '2000', 30, 40),
+			(11, '1862', 30, 40);`,
+	}
+
+	for _, stmt := range statements {
+		if err := db.Exec(stmt).Error; err != nil {
+			t.Fatalf("exec %q: %v", stmt, err)
+		}
+	}
+
+	return db
+}
+
+func TestRepository_ListWorkOrders_OrdersByLatestCreatedFirst(t *testing.T) {
+	db := newListWorkOrdersTestDB(t)
+	repo := NewRepository(&listTestGormEngine{client: db})
+
+	projectID := int64(30)
+	rows, pageInfo, err := repo.ListWorkOrders(
+		context.Background(),
+		domain.WorkOrderFilter{ProjectID: &projectID},
+		types.Input{Page: 1, PageSize: 10},
+	)
+	if err != nil {
+		t.Fatalf("list work orders: %v", err)
+	}
+
+	if pageInfo.Total != 2 {
+		t.Fatalf("expected total 2, got %d", pageInfo.Total)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(rows))
+	}
+	if rows[0].ID != 11 || rows[0].Number != "1862" {
+		t.Fatalf("expected latest created work order first, got id=%d number=%q", rows[0].ID, rows[0].Number)
+	}
+	if rows[1].ID != 10 || rows[1].Number != "2000" {
+		t.Fatalf("expected older work order second, got id=%d number=%q", rows[1].ID, rows[1].Number)
+	}
+}

--- a/migrations_v4/000214_dashboard_last_created_workorder.down.sql
+++ b/migrations_v4/000214_dashboard_last_created_workorder.down.sql
@@ -1,0 +1,53 @@
+-- ========================================
+-- MIGRATION 000214 DASHBOARD LAST CREATED WORKORDER (DOWN)
+-- ========================================
+
+BEGIN;
+
+CREATE OR REPLACE VIEW v4_report.dashboard_operational_indicators AS
+SELECT
+  p.id AS project_id,
+  v4_ssot.first_workorder_date_for_project(p.id) AS start_date,
+  v4_ssot.last_workorder_date_for_project(p.id) AS end_date,
+  v4_core.calculate_campaign_closing_date(
+    v4_ssot.last_workorder_date_for_project(p.id)
+  ) AS campaign_closing_date,
+  v4_ssot.first_workorder_number_for_project(p.id) AS first_workorder_id,
+  v4_ssot.last_workorder_number_for_project(p.id) AS last_workorder_id,
+  v4_ssot.last_stock_count_date_for_project(p.id) AS last_stock_count_date
+FROM public.projects p
+WHERE p.deleted_at IS NULL;
+
+CREATE OR REPLACE VIEW v4_report.dashboard_operational_indicators_field AS
+SELECT
+  p.id AS project_id,
+  p.customer_id,
+  p.campaign_id,
+  f.id AS field_id,
+  (SELECT w2.date FROM public.workorders w2
+   WHERE w2.field_id = f.id AND w2.deleted_at IS NULL
+   ORDER BY w2.date ASC, w2.id ASC LIMIT 1
+  ) AS start_date,
+  (SELECT w2.date FROM public.workorders w2
+   WHERE w2.field_id = f.id AND w2.deleted_at IS NULL
+   ORDER BY w2.date DESC, w2.id DESC LIMIT 1
+  ) AS end_date,
+  v4_core.calculate_campaign_closing_date(
+    (SELECT w2.date FROM public.workorders w2
+     WHERE w2.field_id = f.id AND w2.deleted_at IS NULL
+     ORDER BY w2.date DESC, w2.id DESC LIMIT 1)
+  ) AS campaign_closing_date,
+  (SELECT w2.number::text FROM public.workorders w2
+   WHERE w2.field_id = f.id AND w2.deleted_at IS NULL
+   ORDER BY w2.date ASC, w2.id ASC LIMIT 1
+  ) AS first_workorder_id,
+  (SELECT w2.number::text FROM public.workorders w2
+   WHERE w2.field_id = f.id AND w2.deleted_at IS NULL
+   ORDER BY w2.date DESC, w2.id DESC LIMIT 1
+  ) AS last_workorder_id,
+  v4_ssot.last_stock_count_date_for_project(p.id) AS last_stock_count_date
+FROM public.projects p
+JOIN public.fields f ON f.project_id = p.id AND f.deleted_at IS NULL
+WHERE p.deleted_at IS NULL;
+
+COMMIT;

--- a/migrations_v4/000214_dashboard_last_created_workorder.up.sql
+++ b/migrations_v4/000214_dashboard_last_created_workorder.up.sql
@@ -1,0 +1,70 @@
+-- ========================================
+-- MIGRATION 000214 DASHBOARD LAST CREATED WORKORDER (UP)
+-- ========================================
+-- Ajusta los indicadores operativos para que la card "Última orden de trabajo"
+-- tome la última orden creada (created_at, id) y muestre el number y la date
+-- de esa misma orden. No modifica la lógica de cierre de campaña.
+
+BEGIN;
+
+CREATE OR REPLACE VIEW v4_report.dashboard_operational_indicators AS
+SELECT
+  p.id AS project_id,
+  v4_ssot.first_workorder_date_for_project(p.id) AS start_date,
+  lw.date AS end_date,
+  v4_core.calculate_campaign_closing_date(
+    v4_ssot.last_workorder_date_for_project(p.id)
+  ) AS campaign_closing_date,
+  v4_ssot.first_workorder_number_for_project(p.id) AS first_workorder_id,
+  lw.number::text AS last_workorder_id,
+  v4_ssot.last_stock_count_date_for_project(p.id) AS last_stock_count_date
+FROM public.projects p
+LEFT JOIN LATERAL (
+  SELECT
+    w.date,
+    w.number
+  FROM public.workorders w
+  WHERE w.project_id = p.id
+    AND w.deleted_at IS NULL
+  ORDER BY w.created_at DESC, w.id DESC
+  LIMIT 1
+) lw ON TRUE
+WHERE p.deleted_at IS NULL;
+
+CREATE OR REPLACE VIEW v4_report.dashboard_operational_indicators_field AS
+SELECT
+  p.id AS project_id,
+  p.customer_id,
+  p.campaign_id,
+  f.id AS field_id,
+  (SELECT w2.date FROM public.workorders w2
+   WHERE w2.field_id = f.id AND w2.deleted_at IS NULL
+   ORDER BY w2.date ASC, w2.id ASC LIMIT 1
+  ) AS start_date,
+  lw.date AS end_date,
+  v4_core.calculate_campaign_closing_date(
+    (SELECT w2.date FROM public.workorders w2
+     WHERE w2.field_id = f.id AND w2.deleted_at IS NULL
+     ORDER BY w2.date DESC, w2.id DESC LIMIT 1)
+  ) AS campaign_closing_date,
+  (SELECT w2.number::text FROM public.workorders w2
+   WHERE w2.field_id = f.id AND w2.deleted_at IS NULL
+   ORDER BY w2.date ASC, w2.id ASC LIMIT 1
+  ) AS first_workorder_id,
+  lw.number::text AS last_workorder_id,
+  v4_ssot.last_stock_count_date_for_project(p.id) AS last_stock_count_date
+FROM public.projects p
+JOIN public.fields f ON f.project_id = p.id AND f.deleted_at IS NULL
+LEFT JOIN LATERAL (
+  SELECT
+    w2.date,
+    w2.number
+  FROM public.workorders w2
+  WHERE w2.field_id = f.id
+    AND w2.deleted_at IS NULL
+  ORDER BY w2.created_at DESC, w2.id DESC
+  LIMIT 1
+) lw ON TRUE
+WHERE p.deleted_at IS NULL;
+
+COMMIT;

--- a/resumen estado.md
+++ b/resumen estado.md
@@ -1,0 +1,118 @@
+# Estado Actual Unificado
+
+## 1. Decisiones de negocio confirmadas
+- La numeración de work orders con sufijos como `.1`, `.2`, `.3` es **válida** y debe conservarse.
+- Una work order siempre pertenece a **un campo específico**.
+- `Todos los campos` es solo un **filtro agregado**, no un valor válido al crear una work order.
+- El workspace mínimo válido de la app es:
+  - `customer`
+  - `project`
+  - `campaign`
+- `field` es opcional y, cuando no se elige, significa **`Todos los campos`**.
+
+## 2. Hotfix vigente
+- Rama backend: `dashboard-fix`
+- Rama frontend: `dashboard-fix`
+- Base: `main`
+
+### Qué corrige
+- La card `Última orden de trabajo` del dashboard ahora muestra la **última work order creada**, no la última por `date`.
+- Eso aplica en los dos casos:
+  - proyecto + campaña + todos los campos
+  - proyecto + campaña + un campo específico
+- El BFF del frontend ya no deja el dashboard stale por cache.
+- La fecha de la card quedó formateada correctamente.
+
+### Criterio funcional
+- Con `field` vacío:
+  - la card muestra la última WO creada para ese `customer + project + campaign`, considerando **todos los campos**.
+- Con `field` elegido:
+  - la card muestra la última WO creada para ese campo puntual.
+
+## 3. Qué se descartó
+- Se descartó la línea de trabajo de “normalizar work orders a enteros”.
+- Se descartó también la transición con `legacy_number`.
+- Los PRs de normalización final dejaron de tener sentido porque el negocio confirmó que la numeración con punto es correcta.
+
+## 4. Estado actual de work orders
+- La creación de WO sigue permitiendo numeraciones como `1861.1`, `1860.5`, etc.
+- Eso es correcto según la definición actual del negocio.
+- No hay que introducir ninguna ingeniería para convertir esos números a enteros.
+
+## 5. Regla de visualización y consulta
+- Dashboard:
+  - usa **última creada**
+- Listado de Órdenes de Trabajo (`/admin/work-orders`):
+  - debe usar también **última creada**
+  - ya no “número más alto”
+
+## 6. Cambios locales actualmente hechos y pendientes de commit
+
+### Backend
+- [internal/shared/handlers/workspace_filters.go](/home/pablo/Projects/Pablo/ponti/ponti-backend/internal/shared/handlers/workspace_filters.go)
+  - valida que `customer_id + project_id + campaign_id` sean obligatorios para dashboard/reportes
+- [internal/dashboard/handler.go](/home/pablo/Projects/Pablo/ponti/ponti-backend/internal/dashboard/handler.go)
+  - aplica esa validación al dashboard
+- [internal/report/handler.go](/home/pablo/Projects/Pablo/ponti/ponti-backend/internal/report/handler.go)
+  - aplica esa validación a reportes
+- [internal/report/usecases.go](/home/pablo/Projects/Pablo/ponti/ponti-backend/internal/report/usecases.go)
+- [internal/report/usecases/validators.go](/home/pablo/Projects/Pablo/ponti/ponti-backend/internal/report/usecases/validators.go)
+  - alinean el criterio de workspace mínimo válido
+- [internal/work-order/repository.go](/home/pablo/Projects/Pablo/ponti/ponti-backend/internal/work-order/repository.go)
+  - el listado de work orders quedó ordenado por **última creada** (`id desc`)
+- [internal/work-order/repository_list_test.go](/home/pablo/Projects/Pablo/ponti/ponti-backend/internal/work-order/repository_list_test.go)
+  - test de regresión del orden del listado
+
+### Frontend
+- [ui/src/hooks/useWorkspaceFilters.ts](/home/pablo/Projects/Pablo/ponti/ponti-frontend/ui/src/hooks/useWorkspaceFilters.ts)
+  - `customer + project + campaign` pasan a ser obligatorios para que el workspace sea utilizable
+  - `field` queda opcional
+  - `field` vacío vuelve siempre a `Todos los campos`
+- [ui/src/hooks/useDashboard/index.ts](/home/pablo/Projects/Pablo/ponti/ponti-frontend/ui/src/hooks/useDashboard/index.ts)
+  - limpia estado si el workspace no es válido
+- [ui/src/hooks/useReporting/index.ts](/home/pablo/Projects/Pablo/ponti/ponti-frontend/ui/src/hooks/useReporting/index.ts)
+  - limpia estado si el workspace no es válido
+- [ui/src/pages/admin/dashboard/Dashboard.tsx](/home/pablo/Projects/Pablo/ponti/ponti-frontend/ui/src/pages/admin/dashboard/Dashboard.tsx)
+  - solo consulta dashboard con `customer + project + campaign`
+- [ui/src/pages/admin/reports/SummaryResultsReport.tsx](/home/pablo/Projects/Pablo/ponti/ponti-frontend/ui/src/pages/admin/reports/SummaryResultsReport.tsx)
+- [ui/src/pages/admin/reports/ByFieldOrCropReport.tsx](/home/pablo/Projects/Pablo/ponti/ponti-frontend/ui/src/pages/admin/reports/ByFieldOrCropReport.tsx)
+- [ui/src/pages/admin/reports/InvestorContributionReport.tsx](/home/pablo/Projects/Pablo/ponti/ponti-frontend/ui/src/pages/admin/reports/InvestorContributionReport.tsx)
+  - alineados a workspace mínimo válido
+- [ui/src/pages/admin/database/data-integrity/Integrity.tsx](/home/pablo/Projects/Pablo/ponti/ponti-frontend/ui/src/pages/admin/database/data-integrity/Integrity.tsx)
+  - también queda alineado al workspace mínimo
+- [api/src/routes/reports.ts](/home/pablo/Projects/Pablo/ponti/ponti-frontend/api/src/routes/reports.ts)
+  - reenvía `customer_id`
+
+## 7. Qué ya quedó probado
+- `go test ./...`
+- `go test ./internal/work-order/...`
+- `npm --prefix api run build`
+- `npm --prefix ui run typecheck`
+- `npm --prefix ui run build`
+
+### Prueba funcional real del dashboard
+- Se creó una WO nueva para `project_id=30`.
+- El dashboard pasó a mostrar esa WO como `Última orden de trabajo`.
+- Esto confirmó que la card ya no usa “última por fecha operativa”, sino “última creada”.
+
+## 8. Qué sigue pendiente
+
+### Pendiente funcional/técnico
+- Corregir el swap artificial de arriendo en:
+  - [internal/dashboard/handler/dto/dashboard.go](/home/pablo/Projects/Pablo/ponti/ponti-backend/internal/dashboard/handler/dto/dashboard.go)
+- Agregar tests de regresión reales del dashboard para:
+  - última WO creada por proyecto
+  - última WO creada por campo
+  - validación del workspace mínimo
+  - balance de gestión sin swap artificial
+
+### Pendiente de integración
+- Los cambios de workspace mínimo válido y el cambio de orden del listado están hechos localmente, pero todavía **no están commiteados/pusheados**.
+
+## 9. Resumen corto
+- El hotfix correcto es: **dashboard usa última WO creada**.
+- La numeración con punto **se mantiene**.
+- `legacy_number` y la normalización a enteros quedan descartados.
+- La app debe trabajar con:
+  - `customer + project + campaign` obligatorios
+  - `field` opcional con default `Todos los campos`.


### PR DESCRIPTION
## Objetivo
Corregir la card de `Última orden de trabajo` para que muestre la última work order creada del proyecto/campo y no la última por `date` operativa.

## Qué incluye
- nueva migración `000214_dashboard_last_created_workorder`
- actualización de `v4_report.dashboard_operational_indicators`
- actualización de `v4_report.dashboard_operational_indicators_field`
- criterio nuevo: `ORDER BY created_at DESC, id DESC`

## Qué no incluye
- no toca numeración de work orders
- no agrega `legacy_number`
- no cambia reglas de creación/edición de WO

## Validación
- `go test ./...`
- validación sobre DB local restaurada desde STG
- caso probado: crear una WO nueva con `date` más vieja y verificar que el dashboard igual la tome por ser la última creada
