### PR TITLE
chore(ci): actualizar GitHub Actions a majors vigentes

### DIFF
--- a/.github/workflows/apply-migrations-prod.yml
+++ b/.github/workflows/apply-migrations-prod.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Guardrails
         run: |
@@ -64,13 +64,13 @@ jobs:
           fi
 
       - name: Auth GCP
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ env.WIF_PROVIDER }}
           service_account: ${{ env.WIF_SERVICE_ACCOUNT }}
 
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ env.GCP_PROJECT_ID }}
 

--- a/.github/workflows/audit-service-alignment.yml
+++ b/.github/workflows/audit-service-alignment.yml
@@ -40,13 +40,13 @@ jobs:
 
     steps:
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ matrix.wif_provider }}
           service_account: ${{ matrix.wif_service_account }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ matrix.project_id }}
 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure private Go modules
         run: git config --global url."https://${{ secrets.CORE_REPO_READ_TOKEN }}@github.com/".insteadOf "https://github.com/"
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure private Go modules
         run: git config --global url."https://${{ secrets.CORE_REPO_READ_TOKEN }}@github.com/".insteadOf "https://github.com/"
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure private Go modules
         run: git config --global url."https://${{ secrets.CORE_REPO_READ_TOKEN }}@github.com/".insteadOf "https://github.com/"
@@ -75,7 +75,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure private Go modules
         run: git config --global url."https://${{ secrets.CORE_REPO_READ_TOKEN }}@github.com/".insteadOf "https://github.com/"

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -52,18 +52,18 @@ jobs:
       SERVICE_ENV_MAX_RETRIES: ${{ vars.SERVICE_MAX_RETRIES_ENV }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.ref || github.ref_name }}
 
       - name: Auth GCP
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ env.WIF_PROVIDER }}
           service_account: ${{ env.WIF_SERVICE_ACCOUNT }}
 
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ env.GCP_PROJECT_ID }}
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -62,16 +62,16 @@ jobs:
 
     steps:
       - name: Checkout (solo para metadata)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Auth GCP (STAGING - pull Artifact)
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ env.WIF_PROVIDER_STG }}
           service_account: ${{ env.WIF_SERVICE_ACCOUNT_STG }}
 
       - name: Setup gcloud (STAGING)
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ env.GCP_PROJECT_ID_STG }}
 
@@ -87,13 +87,13 @@ jobs:
           docker pull "$src_image"
 
       - name: Auth GCP (PROD - push + deploy)
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ env.WIF_PROVIDER_PROD }}
           service_account: ${{ env.WIF_SERVICE_ACCOUNT_PROD }}
 
       - name: Setup gcloud (PROD)
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ env.GCP_PROJECT_ID_PROD }}
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -52,18 +52,18 @@ jobs:
       SERVICE_ENV_MAX_RETRIES: ${{ vars.SERVICE_MAX_RETRIES_ENV }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.ref || github.ref_name }}
 
       - name: Auth GCP
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ env.WIF_PROVIDER }}
           service_account: ${{ env.WIF_SERVICE_ACCOUNT }}
 
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ env.GCP_PROJECT_ID }}
 

--- a/.github/workflows/reset-db-dev-from-staging.yml
+++ b/.github/workflows/reset-db-dev-from-staging.yml
@@ -37,16 +37,16 @@ jobs:
       SMOKE_TEST_URL: ${{ vars.SMOKE_TEST_URL }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Auth GCP
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ env.WIF_PROVIDER }}
           service_account: ${{ env.WIF_SERVICE_ACCOUNT }}
 
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ env.GCP_PROJECT_ID }}
 

--- a/.github/workflows/reset-db-staging-from-prod-sanitized.yml
+++ b/.github/workflows/reset-db-staging-from-prod-sanitized.yml
@@ -51,16 +51,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Auth GCP (DEV project - instancia unificada)
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ env.WIF_PROVIDER }}
           service_account: ${{ env.WIF_SERVICE_ACCOUNT }}
 
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ env.GCP_PROJECT_ID }}
 


### PR DESCRIPTION
## Resumen
Actualiza las GitHub Actions de backend a majors vigentes para evitar los warnings por deprecación de Node 20 en runners de GitHub.

## Cambios
- `actions/checkout` a `v6`
- `google-github-actions/auth` a `v3`
- `google-github-actions/setup-gcloud` a `v3`

## Alcance
- Solo workflows de CI/CD
- Sin cambios funcionales de aplicación

## Nota
- `ponti-ai` ya estaba usando versiones actuales y no requirió cambios en este ajuste.